### PR TITLE
ci: build on push and pr, build and publish sdists, publish on v-tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Build and Publish to PyPI
 
-on:
-  push:
-    tags:
-      - "v*.*.*"
+on: [ push, pull_request ]
 
 jobs:
   build:
@@ -48,9 +45,33 @@ jobs:
           name: built-wheels-${{ matrix.os }}-${{ github.run_id }}
           path: dist
 
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build
+        run: python -m pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Upload sdist as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist-${{ github.run_id }}
+          path: dist
+
   publish:
     name: Publish to PyPI
     needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -77,8 +98,13 @@ jobs:
           name: built-wheels-macos-latest-${{ github.run_id }}
           path: dist
 
+      - name: Download sdist
+        uses: actions/download-artifact@v4
+        with:
+          name: sdist-${{github.run_id}}
+          path: dist
+
       - name: Publish to PyPI via Trusted Publisher
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist
-


### PR DESCRIPTION
Hi!

Thanks for setting up CI builds for python-lzf!

I'm packaging pypcd4 and python-lzf in some places, and wanted to package python-neo-lzf for conda-forge and noticed that there's no sdists from this package on PyPi.

I added build steps for the sdist, and upload to artifacts. On the publish steps I added a download step for the sdist.

I made the workflow run on pushes and PR's, but the publish job only runs if it's a tag push.

I can package this for conda-forge without the sdist, but it's still good to push sdist as explained here: https://packaging.python.org/en/latest/discussions/package-formats/#what-is-a-source-distribution